### PR TITLE
Fixed minor bug in the example that was breaking frodo. 

### DIFF
--- a/example-project/resources/chord-example.edn
+++ b/example-project/resources/chord-example.edn
@@ -1,4 +1,5 @@
 {:frodo/config {:web {:port 3000
                       :handler chord.example/app
-                      :cljs-repl? true}
-                :nrepl {:port 7888}}}
+                      }
+                :nrepl {:port 7888 
+                        :cljs-repl? true}}}


### PR DESCRIPTION
cljs-repl? true should be a child of :nrepl
