### PR TITLE
Updating dependency version numbers to match what's current in clojars

### DIFF
--- a/example-project/project.clj
+++ b/example-project/project.clj
@@ -11,16 +11,16 @@
                  [hiccup "1.0.4"]
 
                  [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
-                 [org.clojure/clojurescript "0.0-2173"]
-                 [org.clojure/tools.reader "0.8.3"]
+                 [org.clojure/clojurescript "0.0-2202"]
+                 [org.clojure/tools.reader "0.8.4"]
 
                  [prismatic/dommy "0.1.2"]
 
                  [jarohen/clidget "0.2.0"]]
 
   :plugins [[lein-pdo "0.1.1"]
-            [jarohen/lein-frodo "0.2.11"]
-            [lein-cljsbuild "1.0.2"]]
+            [jarohen/lein-frodo "0.3.0-rc2"]
+            [lein-cljsbuild "1.0.3"]]
 
   :frodo/config-resource "chord-example.edn"
 


### PR DESCRIPTION
Hi! I had to make these changes to the example project config before I was able to get the example project to run (seems like there's a transitive dependency on com.cemerick:austin:jar:0.1.3 somewhere, which no longer seems to exist). 

I'm also trying to make a sort of "starter template" with chord, but I'm having some trouble moving the example project out from underneath the chord directory itself, if I get that working I might have another pull request forthcoming.
