### PR TITLE
Removed dependency on org.clojure/tools.reader because it triggers a JS error

### DIFF
--- a/example-project/project.clj
+++ b/example-project/project.clj
@@ -12,7 +12,6 @@
 
                  [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
                  [org.clojure/clojurescript "0.0-2202"]
-                 [org.clojure/tools.reader "0.8.4"]
 
                  [prismatic/dommy "0.1.2"]
 


### PR DESCRIPTION
Hi James,

  running the example project results, on my system, in a JS error: `Uncaught TypeError: undefined is not a function`. I think the root cause is similar to http://dev.clojure.org/jira/browse/CLJS-685 (`cljs.core.PersistentArrayMap` is undefined). Removing the explicit dependency on `tools.reader` seems to fix it.

cheers,
__
Giuliano
