### PR TITLE
Added support for transit on the wire.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,8 @@
                  [org.clojure/core.async "0.1.301.0-deb34a-alpha"]
                  [http-kit "2.1.18"]
                  [org.clojure/tools.reader "0.8.3"]
+                 [com.cognitect/transit-clj "0.8.259"]
+                 [com.cognitect/transit-cljs "0.8.192"]
                  [cheshire "5.3.1"]]
 
   :plugins [[com.keminglabs/cljx "0.3.2"]]


### PR DESCRIPTION
Thanks for the great little lib, it's saving me a lot of trouble. 

I've added support for transit as the data encoding for my own purposes and thought I'd share it. From past pull requests you seem to be on the fence about how many batteries you want chord to have, and to be honest I don't know if there's a right answer. 

If you think this belongs in the repo then by all means, otherwise I'd be happy enough doing what @rosejn did with chord-fressian. Just give the word. 
